### PR TITLE
Enhance todo items with tags and due dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This project is a simple to-do list web application.
 - Add new tasks using the input field and "Add" button.
 - Check tasks to mark them completed.
 - Delete tasks using the trash button.
-- Edit a task by clicking its text.
+- Edit a task using the ✏️ button.
+- Add colored tags to tasks.
+- Set optional due dates with a calendar picker.
 - Filter tasks by status: all, to-do or completed.
 - Tasks are stored in `localStorage` so they persist after the browser is closed.
 

--- a/app.js
+++ b/app.js
@@ -11,6 +11,10 @@ function loadTasks() {
     if (stored) {
         tasks = JSON.parse(stored);
     }
+    tasks.forEach(t => {
+        if (!t.tags) t.tags = [];
+        if (!t.dueDate) t.dueDate = '';
+    });
 }
 
 function saveTasks() {
@@ -22,32 +26,78 @@ function createTaskElement(task) {
     li.className = 'task-item';
     if (task.completed) li.classList.add('completed');
 
+    const header = document.createElement('div');
+    header.className = 'task-header';
+
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.checked = task.completed;
     checkbox.addEventListener('change', () => {
         task.completed = checkbox.checked;
         saveTasks();
-        renderTasks();
+        renderTasks(currentFilter);
     });
 
     const textSpan = document.createElement('span');
     textSpan.className = 'text';
     textSpan.textContent = task.text;
-    textSpan.addEventListener('click', () => startEditing(task, textSpan));
+
+    const dueSpan = document.createElement('span');
+    dueSpan.className = 'due-date';
+    updateDueDateSpan(dueSpan, task);
+
+    header.append(checkbox, textSpan, dueSpan);
+
+    const tagsDiv = document.createElement('div');
+    tagsDiv.className = 'tags';
+    task.tags.forEach(tag => addTagElement(tag, tagsDiv, task));
+
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+
+    const editBtn = document.createElement('button');
+    editBtn.className = 'edit-btn';
+    editBtn.textContent = '✏️';
+    editBtn.addEventListener('click', e => {
+        e.stopPropagation();
+        startEditing(task, textSpan);
+    });
+
+    const tagBtn = document.createElement('button');
+    tagBtn.className = 'tag-btn';
+    tagBtn.textContent = '+ Tag';
+    tagBtn.addEventListener('click', e => {
+        e.stopPropagation();
+        openTagSelector(task, tagsDiv);
+    });
+
+    const dateBtn = document.createElement('button');
+    dateBtn.className = 'date-btn';
+    dateBtn.textContent = '📅';
+    dateBtn.addEventListener('click', e => {
+        e.stopPropagation();
+        openDatePicker(task, dueSpan);
+    });
 
     const deleteBtn = document.createElement('button');
     deleteBtn.className = 'delete-btn';
     deleteBtn.textContent = '🗑';
-    deleteBtn.addEventListener('click', () => {
+    deleteBtn.addEventListener('click', e => {
+        e.stopPropagation();
         tasks = tasks.filter(t => t !== task);
         saveTasks();
-        renderTasks();
+        renderTasks(currentFilter);
     });
 
-    li.appendChild(checkbox);
-    li.appendChild(textSpan);
-    li.appendChild(deleteBtn);
+    actions.append(editBtn, tagBtn, dateBtn, deleteBtn);
+
+    li.appendChild(header);
+    li.appendChild(tagsDiv);
+    li.appendChild(actions);
+
+    li.addEventListener('click', () => {
+        li.classList.toggle('expanded');
+    });
     return li;
 }
 
@@ -58,15 +108,92 @@ function startEditing(task, textSpan) {
     input.addEventListener('keydown', e => {
         if (e.key === 'Enter') {
             finishEditing();
+        } else if (e.key === 'Escape') {
+            renderTasks(currentFilter);
         }
     });
     const finishEditing = () => {
         task.text = input.value.trim();
         saveTasks();
-        renderTasks();
+        renderTasks(currentFilter);
     };
     input.addEventListener('blur', finishEditing);
     textSpan.replaceWith(input);
+    input.focus();
+}
+
+function addTagElement(tag, container, task) {
+    const span = document.createElement('span');
+    span.className = 'tag';
+    span.style.background = tag.color;
+    span.textContent = tag.label;
+
+    const remove = document.createElement('span');
+    remove.className = 'remove-tag';
+    remove.textContent = '×';
+    remove.addEventListener('click', e => {
+        e.stopPropagation();
+        task.tags = task.tags.filter(t => t !== tag);
+        saveTasks();
+        renderTasks(currentFilter);
+    });
+    span.appendChild(remove);
+    container.appendChild(span);
+}
+
+function openTagSelector(task, container) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'tag-selector';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = 'Tag';
+    const color = document.createElement('input');
+    color.type = 'color';
+    const add = document.createElement('button');
+    add.textContent = 'Add';
+    const finish = () => {
+        const label = input.value.trim();
+        if (label) {
+            task.tags.push({ label, color: color.value });
+            saveTasks();
+            renderTasks(currentFilter);
+        }
+        wrapper.remove();
+    };
+    add.addEventListener('click', finish);
+    input.addEventListener('keydown', e => {
+        if (e.key === 'Enter') finish();
+        if (e.key === 'Escape') wrapper.remove();
+    });
+    wrapper.append(input, color, add);
+    container.appendChild(wrapper);
+    input.focus();
+}
+
+function updateDueDateSpan(span, task) {
+    if (task.dueDate) {
+        span.textContent = 'Due: ' + task.dueDate;
+        const today = new Date();
+        const due = new Date(task.dueDate);
+        today.setHours(0, 0, 0, 0);
+        span.classList.toggle('past-due', due < today);
+    } else {
+        span.textContent = '';
+        span.classList.remove('past-due');
+    }
+}
+
+function openDatePicker(task, span) {
+    const input = document.createElement('input');
+    input.type = 'date';
+    input.value = task.dueDate || '';
+    input.addEventListener('change', () => {
+        task.dueDate = input.value;
+        saveTasks();
+        renderTasks(currentFilter);
+    });
+    input.addEventListener('blur', () => input.remove());
+    span.appendChild(input);
     input.focus();
 }
 
@@ -86,7 +213,7 @@ function renderTasks(filter = 'all') {
 addTaskBtn.addEventListener('click', () => {
     const text = taskInput.value.trim();
     if (text) {
-        tasks.push({ text, completed: false });
+        tasks.push({ text, completed: false, tags: [], dueDate: '' });
         taskInput.value = '';
         saveTasks();
         renderTasks(currentFilter);

--- a/style.css
+++ b/style.css
@@ -38,18 +38,23 @@ button {
 }
 .task-item {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
+    flex-direction: column;
+    align-items: flex-start;
     padding: 8px;
     border-bottom: 1px solid #ddd;
+}
+.task-header {
+    display: flex;
+    align-items: center;
+    width: 100%;
+}
+.task-header .text {
+    flex-grow: 1;
+    margin-left: 8px;
 }
 .task-item.completed .text {
     text-decoration: line-through;
     color: #888;
-}
-.task-item .text {
-    flex-grow: 1;
-    margin-left: 8px;
 }
 .task-item input[type="text"] {
     flex-grow: 1;
@@ -60,4 +65,40 @@ button {
     border: none;
     color: red;
     font-size: 18px;
+}
+
+.tags {
+    margin-top: 5px;
+}
+.tag {
+    display: inline-block;
+    padding: 2px 6px;
+    border-radius: 10px;
+    margin-right: 4px;
+    color: #fff;
+    font-size: 12px;
+}
+.remove-tag {
+    margin-left: 4px;
+    cursor: pointer;
+}
+.due-date {
+    margin-left: 10px;
+    font-size: 12px;
+}
+.past-due {
+    color: red;
+}
+.actions {
+    display: none;
+    gap: 5px;
+    margin-top: 5px;
+}
+.task-item.expanded .actions {
+    display: flex;
+}
+.tag-selector {
+    display: flex;
+    gap: 4px;
+    margin-top: 4px;
 }


### PR DESCRIPTION
## Summary
- allow editing via ✏️ button
- add colored tags and remove them
- support setting due dates
- show extra controls when item expanded

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685f089f0ed8832c9380819c12781fb2