### PR TITLE
Add tag suggestion feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -168,6 +168,16 @@ function openTagSelector(task, container) {
     color.type = 'color';
     const add = document.createElement('button');
     add.textContent = 'Add';
+    const suggestions = document.createElement('div');
+    suggestions.className = 'tag-suggestions';
+
+    const usedTags = {};
+    tasks.forEach(t => {
+        t.tags.forEach(tag => {
+            if (!usedTags[tag.label]) usedTags[tag.label] = tag.color;
+        });
+    });
+
     const finish = () => {
         const label = input.value.trim();
         if (label) {
@@ -182,7 +192,30 @@ function openTagSelector(task, container) {
         if (e.key === 'Enter') finish();
         if (e.key === 'Escape') wrapper.remove();
     });
-    wrapper.append(input, color, add);
+
+    function updateSuggestions() {
+        suggestions.innerHTML = '';
+        const text = input.value.trim().toLowerCase();
+        if (!text) return;
+        Object.entries(usedTags).forEach(([label, col]) => {
+            if (label.toLowerCase().startsWith(text)) {
+                const item = document.createElement('div');
+                item.className = 'suggestion';
+                item.textContent = label;
+                item.style.background = col;
+                item.addEventListener('click', () => {
+                    input.value = label;
+                    color.value = col;
+                    finish();
+                });
+                suggestions.appendChild(item);
+            }
+        });
+    }
+
+    input.addEventListener('input', updateSuggestions);
+
+    wrapper.append(input, color, add, suggestions);
     container.appendChild(wrapper);
     input.focus();
 }

--- a/style.css
+++ b/style.css
@@ -102,3 +102,23 @@ button {
     gap: 4px;
     margin-top: 4px;
 }
+
+.tag-suggestions {
+    display: flex;
+    flex-direction: column;
+    margin-top: 4px;
+    border: 1px solid #ccc;
+    background: #fff;
+    max-height: 100px;
+    overflow-y: auto;
+}
+
+.tag-suggestions .suggestion {
+    padding: 2px 6px;
+    color: #fff;
+    cursor: pointer;
+}
+
+.tag-suggestions .suggestion:hover {
+    opacity: 0.8;
+}


### PR DESCRIPTION
## Summary
- show suggestions for tags when typing new one
- apply selected suggestion immediately with stored color
- style suggestion list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686025efbf7c832c91b795a6392bb8be