### PR TITLE
Implement priority and description editing

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
             <input type="text" id="new-task" placeholder="Add a new task">
             <button id="add-task">Add</button>
         </div>
+        <button id="toggle-options" class="options-btn">More Options</button>
+        <div id="task-options" class="options hidden">
+            <textarea id="new-description" placeholder="Description"></textarea>
+        </div>
         <div class="filters">
             <button data-filter="all" class="filter active">All</button>
             <button data-filter="active" class="filter">To-Do</button>

--- a/style.css
+++ b/style.css
@@ -122,3 +122,30 @@ button {
 .tag-suggestions .suggestion:hover {
     opacity: 0.8;
 }
+
+.hidden {
+    display: none;
+}
+
+.options {
+    margin-top: 10px;
+}
+
+.priority {
+    margin-left: 10px;
+    font-size: 18px;
+}
+
+.description {
+    margin-left: 28px;
+    margin-top: 4px;
+}
+
+.edit-description {
+    width: 100%;
+    margin-top: 4px;
+}
+
+.priority-select {
+    margin-left: 10px;
+}


### PR DESCRIPTION
## Summary
- allow entering description when creating tasks
- add priority levels with visual icons
- store priority and description for tasks
- style new elements and prioritize icons

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68602870fd54832cadfde27c18ab7b91