### PR TITLE
Add Firebase auth with per-user tasks

### DIFF
--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -1,8 +1,7 @@
 // firebaseConfig.js
-import { initializeApp } from "firebase/app";
-import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
-import { getAnalytics } from "firebase/analytics";
+import { initializeApp } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js";
+import { getAuth } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
+import { getFirestore } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
 
 const firebaseConfig = {
   apiKey: "AIzaSyAhvBttl3n7SqU9rDeGIZTrdspnwoVm6f4",

--- a/index.html
+++ b/index.html
@@ -7,9 +7,7 @@
   <title>Todo List</title>
   <link rel="stylesheet" href="style.css">
 
-  <!-- Firebase -->
-  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+  <!-- Firebase modules are imported via ES modules in the code -->
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- switch firebaseConfig to CDN module imports
- support sign-up/login/logout and task storage per user
- remove unused compat script tags

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860657d2510832c8e05732b73c58f87