### PR TITLE
Add Firebase Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ This project is a simple to-do list web application.
 ## Usage
 
 Open `index.html` in a web browser. No additional build step is required.
+
+## Analytics
+
+This project now includes Firebase Analytics initialization in
+`firebaseConfig.js` with the measurement ID `G-4N6RYDDYKC`.
+If you would like to use your own Analytics property, replace this ID in the
+configuration file with the one from your Firebase console.

--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -2,6 +2,7 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js";
 import { getAuth } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
 import { getFirestore } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
+import { getAnalytics } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-analytics.js";
 
 const firebaseConfig = {
   apiKey: "AIzaSyAhvBttl3n7SqU9rDeGIZTrdspnwoVm6f4",
@@ -9,9 +10,11 @@ const firebaseConfig = {
   projectId: "to-do-list-d31a1",
   storageBucket: "to-do-list-d31a1.firebasestorage.app",
   messagingSenderId: "212406609459",
-  appId: "1:212406609459:web:6f60905f5922233dbd2546"
+  appId: "1:212406609459:web:6f60905f5922233dbd2546",
+  measurementId: "G-4N6RYDDYKC"
 };
 
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
+export const analytics = getAnalytics(app);


### PR DESCRIPTION
## Summary
- configure Firebase analytics with the provided measurement ID
- document the included analytics ID in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861587d6d74832cb1515e92898ac9f7