### PR TITLE
Improve logout process

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,11 +53,19 @@ window.login = async function () {
 };
 
 window.logout = async function () {
-    await saveTasks();
-    await signOut(auth);
-    tasks = [];
-    renderTasks(currentFilter);
-    alert('Déconnecté !');
+    try {
+        await saveTasks();
+    } catch (error) {
+        console.error('Failed to save tasks before logout:', error);
+    }
+    try {
+        await signOut(auth);
+        tasks = [];
+        renderTasks(currentFilter);
+        alert('Déconnecté !');
+    } catch (error) {
+        alert('Erreur lors de la déconnexion: ' + error.message);
+    }
 };
 
 onAuthStateChanged(auth, async user => {


### PR DESCRIPTION
## Summary
- make sure logout still runs if saving tasks fails

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68619823c878832c8f3d0c05cc8f4797