### PR TITLE
Add clean kanban styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -143,6 +143,7 @@ async function loadTasks() {
         if (!t.createdAt) t.createdAt = new Date().toISOString();
         if (!t.updatedAt) t.updatedAt = t.createdAt;
         if (!t.category) t.category = 'Uncategorized';
+        if (!t.assignee) t.assignee = currentUser ? currentUser.email : '';
         if (!t.id) t.id = generateId();
         t.editing = false;
     });
@@ -175,6 +176,10 @@ function createTaskElement(task) {
 
     const header = document.createElement('div');
     header.className = 'task-header';
+
+    const avatar = document.createElement('div');
+    avatar.className = 'avatar';
+    avatar.textContent = task.assignee ? task.assignee[0].toUpperCase() : '?';
 
     const dueSpan = document.createElement('span');
     dueSpan.className = 'due-date';
@@ -246,7 +251,7 @@ function createTaskElement(task) {
         textSpan = input;
         priorityElement = select;
         descElement = descInput;
-        header.append(checkbox, textSpan, priorityElement, dueSpan, saveBtn, cancelBtn);
+        header.append(checkbox, avatar, textSpan, priorityElement, saveBtn, cancelBtn);
         li.appendChild(header);
         li.appendChild(descElement);
     } else {
@@ -270,7 +275,7 @@ function createTaskElement(task) {
         descElement.className = 'description';
         descElement.textContent = task.description;
 
-        header.append(checkbox, textSpan, priorityElement, dueSpan);
+        header.append(checkbox, avatar, textSpan, priorityElement);
         li.appendChild(header);
         if (task.description) li.appendChild(descElement);
     }
@@ -309,7 +314,12 @@ function createTaskElement(task) {
 
     actions.append(tagBtn, dateBtn, deleteBtn);
 
+    const meta = document.createElement('div');
+    meta.className = 'metadata';
+    meta.appendChild(dueSpan);
+
     li.appendChild(tagsDiv);
+    li.appendChild(meta);
     li.appendChild(actions);
 
     li.addEventListener('click', () => {
@@ -540,6 +550,7 @@ function renderBoard(filter = 'all') {
         }
 
         const addBtn = document.createElement('button');
+        addBtn.className = 'add-task-column';
         addBtn.innerHTML = '<i data-feather="plus" class="button-icon"></i> Add task';
         addBtn.addEventListener('click', () => {
             const text = prompt('Task name');
@@ -555,7 +566,8 @@ function renderBoard(filter = 'all') {
                     createdAt: new Date().toISOString(),
                     updatedAt: new Date().toISOString(),
                     editing: false,
-                    category: cat
+                    category: cat,
+                    assignee: currentUser ? currentUser.email : ''
                 });
                 saveTasks();
                 renderBoard(currentFilter);
@@ -590,8 +602,8 @@ function renderBoard(filter = 'all') {
         });
 
         column.appendChild(header);
-        column.appendChild(addBtn);
         column.appendChild(ul);
+        column.appendChild(addBtn);
         board.appendChild(column);
     });
 
@@ -622,7 +634,8 @@ addTaskBtn.addEventListener('click', () => {
             createdAt: new Date().toISOString(),
             updatedAt: new Date().toISOString(),
             editing: false,
-            category: 'Uncategorized'
+            category: 'Uncategorized',
+            assignee: currentUser ? currentUser.email : ''
         });
         taskInput.value = '';
         newDescription.value = '';
@@ -654,7 +667,8 @@ taskInput.addEventListener('keydown', e => {
                 createdAt: new Date().toISOString(),
                 updatedAt: new Date().toISOString(),
                 editing: false,
-                category: 'Uncategorized'
+                category: 'Uncategorized',
+                assignee: currentUser ? currentUser.email : ''
             });
             taskInput.value = '';
             newDescription.value = '';

--- a/index.html
+++ b/index.html
@@ -31,7 +31,9 @@
   </div>
 
   <div id="todo-app" class="todo-app hidden">
-    <h1>Todo List</h1>
+    <header class="app-header">
+      <h1>Kanban Board</h1>
+    </header>
     <div class="input-group">
       <input type="text" id="new-task" placeholder="Add a new task">
       <button id="add-task">Add</button>

--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@
     --radius: 16px;
     --shadow: 0 4px 12px rgba(0,0,0,0.1);
     --panel-bg: rgba(255,255,255,0.6);
+    --card-bg: #fff;
     --bg: #f5f5f5;
     --text: #111;
     --transition: 0.2s ease-in-out;
@@ -11,6 +12,7 @@
 @media (prefers-color-scheme: dark) {
     :root {
         --panel-bg: rgba(40,40,40,0.6);
+        --card-bg: #2b2b2b;
         --bg: #1c1c1c;
         --text: #fafafa;
         --shadow: 0 4px 12px rgba(0,0,0,0.5);
@@ -33,6 +35,26 @@ body {
     border-radius: var(--radius);
     backdrop-filter: blur(20px);
     transition: background var(--transition), box-shadow var(--transition);
+}
+
+.app-header {
+    position: sticky;
+    top: 0;
+    background: var(--panel-bg);
+    padding: 10px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 10px;
+    box-shadow: var(--shadow);
+    border-radius: var(--radius);
+    backdrop-filter: blur(10px);
+    z-index: 10;
+}
+
+.app-header h1 {
+    margin: 0;
+    font-weight: 600;
 }
 .input-group {
     display: flex;
@@ -85,9 +107,8 @@ button:focus {
     align-items: flex-start;
     padding: 12px;
     margin-bottom: 12px;
-    background: var(--panel-bg);
-    backdrop-filter: blur(10px);
-    border-radius: var(--radius);
+    background: var(--card-bg);
+    border-radius: 12px;
     box-shadow: var(--shadow);
     transition: box-shadow var(--transition), transform var(--transition);
 }
@@ -127,9 +148,10 @@ button:focus {
 .tag {
     display: inline-block;
     padding: 2px 6px;
-    border-radius: 10px;
+    border-radius: 999px;
     margin-right: 4px;
     color: #fff;
+    font-weight: bold;
     font-size: 12px;
 }
 .remove-tag {
@@ -137,6 +159,23 @@ button:focus {
     cursor: pointer;
     display: inline-flex;
     align-items: center;
+}
+.avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: #ccc;
+    color: #fff;
+    font-size: 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 6px;
+}
+
+.metadata {
+    font-size: 12px;
+    margin-top: 4px;
 }
 .due-date {
     margin-left: 10px;
@@ -218,6 +257,8 @@ button:focus {
 }
 
 .category-column {
+    display: flex;
+    flex-direction: column;
     background: var(--panel-bg);
     padding: 10px;
     min-width: 200px;
@@ -242,6 +283,17 @@ button:focus {
     list-style: none;
     padding: 0;
     margin-top: 10px;
+}
+
+.add-task-column {
+    align-self: center;
+    margin-top: 10px;
+    background: transparent;
+    color: var(--text);
+}
+
+.add-task-column:hover {
+    background: var(--panel-bg);
 }
 
 .category-btn {


### PR DESCRIPTION
## Summary
- tune overall look-and-feel with card backgrounds and pastel tags
- add sticky header
- add avatar and metadata areas on task cards
- move add-task button to bottom of column

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6862f6baeb00832c842265390bd8ead2